### PR TITLE
Fix validation error spam when resizing the window

### DIFF
--- a/src/main/java/com/github/knokko/boiler/swapchain/BoilerSwapchains.java
+++ b/src/main/java/com/github/knokko/boiler/swapchain/BoilerSwapchains.java
@@ -111,7 +111,10 @@ public class BoilerSwapchains {
             int presentResult = vkQueuePresentKHR(
                     instance.queueFamilies().present().queues().get(0).vkQueue(), presentInfo
             );
-            if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) return;
+            if (presentResult == VK_ERROR_OUT_OF_DATE_KHR || presentResult == VK_SUBOPTIMAL_KHR) {
+                recreateSwapchain(currentSwapchain.presentMode);
+                return;
+            }
             assertVkSuccess(presentResult, "QueuePresentKHR", null);
             assertVkSuccess(Objects.requireNonNull(presentInfo.pResults()).get(0), "QueuePresentKHR", null);
         }

--- a/src/main/java/com/github/knokko/boiler/swapchain/Swapchain.java
+++ b/src/main/java/com/github/knokko/boiler/swapchain/Swapchain.java
@@ -89,8 +89,7 @@ class Swapchain {
                 acquireIndex = (acquireIndex + 1) % images.length;
                 acquireCounter += 1;
 
-                if (acquireResult == VK_SUCCESS) return image;
-                else return null;
+                return image;
             } else outOfDateIndex = acquireIndex;
 
             if (acquireResult == VK_ERROR_OUT_OF_DATE_KHR) return null;


### PR DESCRIPTION
When vkAcquireNextImageKHR returns an image with VK_SUBOPTIMAL_KHR, its semaphore gets signalled.

Previously, this suboptimal image just got discarded, leaving the semaphore permanently signalled, triggering vulkan errors when that semaphore eventually got returned into the semaphore bank and reused by a new swapchain:

```
VUID-vkAcquireNextImageKHR-semaphore-01286(ERROR / SPEC): msgNum: -370888023 - Validation Error: [ VUID-vkAcquireNextImageKHR-semaphore-01286 ] Object 0: handle = 0xab64de0000000020, name = Borrowed, type = VK_OBJECT_TYPE_SEMAPHORE; | MessageID = 0xe9e4b2a9 | vkAcquireNextImageKHR():  Semaphore must not be currently signaled. The Vulkan spec states: If semaphore is not VK_NULL_HANDLE it must be unsignaled (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkAcquireNextImageKHR-semaphore-01286)
    Objects: 1
        [0] 0xab64de0000000020, type: 5, name: Borrowed
```

This patch adds a workaround that lets the suboptimal swapchain pass through as if it was a regular one, thus letting the signalled semaphore get waited on by render code, but still creates a new swapchain for the next time acquire is called.

The `Swapchain.acquire()` method is package-private, so the public API is not modified.